### PR TITLE
Lazily resolve babel plugins and presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /tmp/
 Gemfile.lock
 node_modules
+test/test_apps/**/public/assets

--- a/test/sprockets/bumble_d/transformer_test.rb
+++ b/test/sprockets/bumble_d/transformer_test.rb
@@ -281,8 +281,9 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
         transformer.call(input)
 
         plugins = ['external-helpers']
-        Resolver.any_instance.expects(:resolve_plugins).with(plugins).once
         transformer = new_transformer(plugins: plugins)
+
+        Resolver.any_instance.expects(:resolve_plugins).with(plugins).once
         transformer.call(input)
       end
 
@@ -299,8 +300,9 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
         transformer.call(input)
 
         presets = ['es2015']
-        Resolver.any_instance.expects(:resolve_presets).with(presets).once
         transformer = new_transformer(presets: presets)
+
+        Resolver.any_instance.expects(:resolve_presets).with(presets).once
         transformer.call(input)
       end
 

--- a/test/sprockets/bumble_d/transformer_test.rb
+++ b/test/sprockets/bumble_d/transformer_test.rb
@@ -268,7 +268,21 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
         assert_equal expected_output, transformer.call(input)
       end
 
-      def test_it_resolves_plugin_arrays
+      def test_it_instantiates_resolver_only_the_first_time_call_is_invoked
+        input = input_exemplar
+        resolver = Resolver.new(Transformer::BabelBridge.new(File.expand_path(__dir__)))
+        Resolver.expects(:new).never
+
+        transformer = new_transformer(presets: ['es2015'])
+
+        Resolver.expects(:new).returns(resolver).once
+
+        transformer.call(input)
+        other_input = input_exemplar(data: 'const foo = "bar"')
+        transformer.call(other_input)
+      end
+
+      def test_it_resolves_plugin_arrays_the_first_time_call_is_invoked
         input = input_exemplar
         Resolver.any_instance.expects(:resolve_plugins).never
 
@@ -285,9 +299,13 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
 
         Resolver.any_instance.expects(:resolve_plugins).with(plugins).once
         transformer.call(input)
+
+        Resolver.any_instance.expects(:resolve_plugins).never
+        other_input = input_exemplar(data: 'const foo = "bar"')
+        transformer.call(other_input)
       end
 
-      def test_it_resolves_preset_arrays
+      def test_it_resolves_preset_arrays_the_first_time_call_is_invoked
         input = input_exemplar
         Resolver.any_instance.expects(:resolve_presets).never
 
@@ -304,6 +322,10 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
 
         Resolver.any_instance.expects(:resolve_presets).with(presets).once
         transformer.call(input)
+
+        Resolver.any_instance.expects(:resolve_presets).never
+        other_input = input_exemplar(data: 'const foo = "bar"')
+        transformer.call(other_input)
       end
 
       private

--- a/test/sprockets/bumble_d/transformer_test.rb
+++ b/test/sprockets/bumble_d/transformer_test.rb
@@ -270,9 +270,9 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
 
       def test_it_resolves_plugin_arrays
         input = input_exemplar
-        plugins = nil
-
         Resolver.any_instance.expects(:resolve_plugins).never
+
+        plugins = nil
         transformer = new_transformer(plugins: plugins)
         transformer.call(input)
 
@@ -288,10 +288,9 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
 
       def test_it_resolves_preset_arrays
         input = input_exemplar
+        Resolver.any_instance.expects(:resolve_presets).never
 
         presets = nil
-
-        Resolver.any_instance.expects(:resolve_presets).never
         transformer = new_transformer(presets: presets)
         transformer.call(input)
 

--- a/test/sprockets/bumble_d/transformer_test.rb
+++ b/test/sprockets/bumble_d/transformer_test.rb
@@ -249,11 +249,14 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
       def test_cache_works
         input = input_exemplar
 
-        transformer = new_transformer(presets: ['es2015'])
+        presets = ['es2015']
+        transformer = new_transformer(presets: presets)
         transformer.expects(:cache_key_from_input).with(input).returns('cache_key').twice
 
         mock_result = { 'code' => 'transformed' }
-        transformer.expects(:babel).returns(mock(transform: mock_result)).once
+        babel_mock = mock(transform: mock_result)
+        babel_mock.expects(:resolvePreset).with(presets.first)
+        transformer.expects(:babel).returns(babel_mock).twice
 
         expected_output = { data: 'transformed' }
         assert_equal expected_output, transformer.call(input)
@@ -266,31 +269,40 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
       end
 
       def test_it_resolves_plugin_arrays
+        input = input_exemplar
         plugins = nil
 
         Resolver.any_instance.expects(:resolve_plugins).never
-        new_transformer(plugins: plugins)
+        transformer = new_transformer(plugins: plugins)
+        transformer.call(input)
 
         plugins = 'external-helpers'
-        new_transformer(plugins: plugins)
+        transformer = new_transformer(plugins: plugins)
+        transformer.call(input)
 
         plugins = ['external-helpers']
         Resolver.any_instance.expects(:resolve_plugins).with(plugins).once
-        new_transformer(plugins: plugins)
+        transformer = new_transformer(plugins: plugins)
+        transformer.call(input)
       end
 
       def test_it_resolves_preset_arrays
+        input = input_exemplar
+
         presets = nil
 
         Resolver.any_instance.expects(:resolve_presets).never
-        new_transformer(presets: presets)
+        transformer = new_transformer(presets: presets)
+        transformer.call(input)
 
         presets = 'es2015'
-        new_transformer(presets: presets)
+        transformer = new_transformer(presets: presets)
+        transformer.call(input)
 
         presets = ['es2015']
         Resolver.any_instance.expects(:resolve_presets).with(presets).once
-        new_transformer(presets: presets)
+        transformer = new_transformer(presets: presets)
+        transformer.call(input)
       end
 
       private

--- a/test/sprockets/bumble_d/transformer_test.rb
+++ b/test/sprockets/bumble_d/transformer_test.rb
@@ -8,14 +8,7 @@ module Sprockets
   module BumbleD
     class TransformerTest < Minitest::Test
       def test_it_compiles_es6_features_to_es5
-        input = {
-          content_type: 'application/ecmascript-6',
-          data: 'const square = (n) => n * n',
-          metadata: {},
-          load_path: File.expand_path('../foo', __FILE__),
-          filename: File.expand_path('../foo/bar.es6', __FILE__),
-          cache: Sprockets::Cache.new
-        }
+        input = input_exemplar
 
         es6_transformer = new_transformer(presets: ['es2015'])
 
@@ -38,15 +31,12 @@ import bar from 'bar/module';
 export default 42;
         JS
 
-        input = {
-          content_type: 'application/ecmascript-6',
+        input = input_exemplar(
           data: es6_module,
-          metadata: {},
           load_path: File.expand_path('../some/dir', __FILE__),
           filename: File.expand_path('../some/dir/mod.es6', __FILE__),
-          cache: Sprockets::Cache.new,
           name: 'some/dir/mod'
-        }
+        )
 
         babel_options = {
           presets: ['es2015'],
@@ -103,15 +93,12 @@ import Tooltip from 'foo/ui/tooltip/module';
 export default 42;
         JS
 
-        input = {
-          content_type: 'application/ecmascript-6',
+        input = input_exemplar(
           data: es6_module,
-          metadata: {},
           load_path: File.expand_path('../some/dir', __FILE__),
           filename: File.expand_path('../some/dir/mod.es6', __FILE__),
-          cache: Sprockets::Cache.new,
           name: 'some/dir/mod'
-        }
+        )
 
         babel_options = {
           presets: ['es2015'],
@@ -168,15 +155,12 @@ import bar from 'bar/module';
 export default 42;
         JS
 
-        input = {
-          content_type: 'application/ecmascript-6',
+        input = input_exemplar(
           data: es6_module,
-          metadata: {},
           load_path: File.expand_path('../some/dir', __FILE__),
           filename: File.expand_path('../some/dir/mod.es6', __FILE__),
-          cache: Sprockets::Cache.new,
           name: 'some/dir/mod'
-        }
+        )
 
         babel_options = {
           presets: ['es2015'],
@@ -232,14 +216,7 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
       end
 
       def test_cache_key_from_input
-        input = {
-          content_type: 'application/ecmascript-6',
-          data: 'const square = (n) => n * n',
-          metadata: {},
-          load_path: File.expand_path('../foo', __FILE__),
-          filename: File.expand_path('../foo/bar.es6', __FILE__),
-          cache: Sprockets::Cache.new
-        }
+        input = input_exemplar
 
         transformer_options = { presets: ['es2015'] }
         transformer = new_transformer(transformer_options)
@@ -270,14 +247,7 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
       end
 
       def test_cache_works
-        input = {
-          content_type: 'application/ecmascript-6',
-          data: 'const square = (n) => n * n',
-          metadata: {},
-          load_path: File.expand_path('../foo', __FILE__),
-          filename: File.expand_path('../foo/bar.es6', __FILE__),
-          cache: Sprockets::Cache.new
-        }
+        input = input_exemplar
 
         transformer = new_transformer(presets: ['es2015'])
         transformer.expects(:cache_key_from_input).with(input).returns('cache_key').twice
@@ -331,6 +301,17 @@ define('some/dir/mod', ['exports', 'foo/module', 'bar/module'], function (export
           babel_config_version: 1
         }
         Transformer.new(default_options.merge(options))
+      end
+
+      def input_exemplar(overrides = {})
+        {
+          content_type: 'application/ecmascript-6',
+          data:         'const square = (n) => n * n',
+          metadata:     {},
+          load_path:    File.expand_path('../foo', __FILE__),
+          filename:     File.expand_path('../foo/bar.es6', __FILE__),
+          cache:        Sprockets::Cache.new
+        }.merge(overrides)
       end
     end
   end


### PR DESCRIPTION
This pull moves the resolution of babel plugins and presets into the `call` method of `Transformer` so that an app that pulls in sprockets-bumble_d won't blow up when running tests if node modules are not installed and those tests don't actually compile assets.