### PR TITLE
Make the sprockets transformer extension configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ that is compatible with non-converted code (e.g. existing UMD modules and
 plain old global-dependent scripts).
 
 Sprockets::BumbleD provides this with a Sprockets transformer that acts on
-`.es6` files. These files are transpiled by Babel and the
-[ES2015 -> UMD modules transform] plugin, preserving any globals that you've
-[registered](#registering-globals).
+`.es6` files (this file extension is
+[configurable](#customizing-the-file-extension)). These files are transpiled by
+Babel and the [ES2015 -> UMD modules transform] plugin, preserving any globals
+that you've [registered](#registering-globals).
 
 [ES2015 -> UMD modules transform]: https://github.com/babel/babel/tree/v7.3.4/packages/babel-plugin-transform-modules-umd
 
@@ -94,6 +95,17 @@ end
 ```
 
 You can specify any options that are allowed in a `.babelrc` file.
+
+### Customizing the file extension
+
+By default the Sprockets transformer is registered to act on `.es6` files. This
+is configurable:
+```ruby
+configure_sprockets_bumble_d do |config|
+  config.babel_config_version = 1
+  config.file_extension = '.babel'
+end
+```
 
 ### The `babel_config_version` setting
 

--- a/lib/sprockets/bumble_d/config.rb
+++ b/lib/sprockets/bumble_d/config.rb
@@ -5,11 +5,13 @@ module Sprockets
     class Config
       attr_accessor :babel_config_version,
                     :babel_options,
+                    :file_extension,
                     :root_dir,
                     :transform_to_umd
       attr_reader :globals_map
 
       def initialize
+        @file_extension = '.es6'
         @globals_map = {}.freeze
         @transform_to_umd = true
         @babel_options = {

--- a/lib/sprockets/bumble_d/config.rb
+++ b/lib/sprockets/bumble_d/config.rb
@@ -3,8 +3,8 @@ require 'sprockets/bumble_d/errors'
 module Sprockets
   module BumbleD
     class Config
-      attr_accessor :babel_options,
-                    :babel_config_version,
+      attr_accessor :babel_config_version,
+                    :babel_options,
                     :root_dir,
                     :transform_to_umd
       attr_reader :globals_map

--- a/lib/sprockets/bumble_d/config.rb
+++ b/lib/sprockets/bumble_d/config.rb
@@ -3,7 +3,10 @@ require 'sprockets/bumble_d/errors'
 module Sprockets
   module BumbleD
     class Config
-      attr_accessor :babel_options, :babel_config_version, :root_dir, :transform_to_umd
+      attr_accessor :babel_options,
+                    :babel_config_version,
+                    :root_dir,
+                    :transform_to_umd
       attr_reader :globals_map
 
       def initialize

--- a/lib/sprockets/bumble_d/railtie.rb
+++ b/lib/sprockets/bumble_d/railtie.rb
@@ -28,7 +28,7 @@ module Sprockets
           root_dir: root_dir,
           babel_config_version: babel_config_version
         )
-        es6_transformer = Transformer.new(options)
+        babel_transformer = Transformer.new(options)
 
         # Using the deprecated register_engine rather than register_mime_type
         # and register_transformer because otherwise .es6 files that aren't
@@ -36,7 +36,7 @@ module Sprockets
         # https://github.com/rails/sprockets/issues/384
         Sprockets.register_engine(
           '.es6',
-          es6_transformer,
+          babel_transformer,
           mime_type: 'application/javascript',
           silence_deprecation: true
         )

--- a/lib/sprockets/bumble_d/railtie.rb
+++ b/lib/sprockets/bumble_d/railtie.rb
@@ -35,7 +35,7 @@ module Sprockets
         # in the precompile list will get unnecessarily compiled. See
         # https://github.com/rails/sprockets/issues/384
         Sprockets.register_engine(
-          '.es6',
+          bumble_d_config.file_extension,
           babel_transformer,
           mime_type: 'application/javascript',
           silence_deprecation: true

--- a/test/sprockets/bumble_d/config_test.rb
+++ b/test/sprockets/bumble_d/config_test.rb
@@ -51,6 +51,7 @@ module Sprockets
 
         assert_nil config.root_dir
         assert_equal true, config.transform_to_umd
+        assert_equal '.es6', config.file_extension
         assert_equal default_babel_options, config.babel_options
 
         custom_babel_options = {
@@ -61,11 +62,13 @@ module Sprockets
         config.configure do |c|
           c.root_dir = File.expand_path(__dir__)
           c.transform_to_umd = false
+          c.file_extension = '.babel'
           c.babel_options = custom_babel_options
         end
 
         assert_equal File.expand_path(__dir__), config.root_dir
         assert_equal false, config.transform_to_umd
+        assert_equal '.babel', config.file_extension
         assert_equal custom_babel_options, config.babel_options
       end
     end


### PR DESCRIPTION
Previously, the sprockets transformer provided by this plugin was explicitly registered for the `.es6` extension. Now it can be configured to any value, though it still defaults to '.es6'.