### PR TITLE
Default the root_dir setting to Rails.root.to_s in Rails applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,32 @@ In `config/application.rb`:
 extend Sprockets::BumbleD::DSL
 
 configure_sprockets_bumble_d do |config|
+  config.babel_config_version = 1
+end
+```
+
+If you are not using Rails, you must also configure the `root_dir` (see below).
+
+### Customizing the `root_dir`
+
+Sprockets::BumbleD needs to know the directory from which node modules are to
+be resolved (typically, wherever your `package.json` resides). If you're using
+Rails, this defaults to `Rails.root.to_s`. If you are not using Rails, or if
+your node_modules folder is not inside `Rails.root`, you **must** configure the
+`root_dir` setting! For example, if you are configuring Sprockets::BumbleD in
+the file `config/application.rb` and your `package.json` is located in the
+parent directory, use:
+
+```ruby
+configure_sprockets_bumble_d do |config|
   config.root_dir = File.expand_path('..', __dir__)
   config.babel_config_version = 1
 end
 ```
 
-The `root_dir` setting is **required**! This tells Sprockets::BumbleD the
-directory from which node modules are to be resolved (typically, wherever your
-package.json resides). If that's `Rails.root.to_s`, use that. If it's in a
-specific subdirectory, specify that. Sprockets::BumbleD doesn't care, as long
-as its node `require` statements will resolve from that directory.
+If it's in a specific subdirectory, specify that directory instead.
+Sprockets::BumbleD doesn't care, as long as its node `require` statements will
+resolve from that directory.
 
 ### Customizing your babel options
 
@@ -85,7 +101,6 @@ plugin does not need to be specified when you override the default plugins.
 For example:
 ```ruby
 configure_sprockets_bumble_d do |config|
-  config.root_dir = File.expand_path('..', __dir__)
   config.babel_config_version = 2
   config.babel_options = {
     presets: ['@babel/preset-env', '@babel/preset-react'],

--- a/lib/sprockets/bumble_d/railtie.rb
+++ b/lib/sprockets/bumble_d/railtie.rb
@@ -6,6 +6,7 @@ module Sprockets
     class Railtie < ::Rails::Railtie
       config.before_configuration do
         config.sprockets_bumble_d = Config.new
+        config.sprockets_bumble_d.root_dir = ::Rails.root.to_s
       end
 
       initializer 'sprockets-bumble_d.configure_transformer' do |app|

--- a/test/test_apps/4.2/config/application.rb
+++ b/test/test_apps/4.2/config/application.rb
@@ -27,7 +27,6 @@ module TestApp
     # config.i18n.default_locale = :de
 
     configure_sprockets_bumble_d do |config|
-      config.root_dir = File.expand_path('..', __dir__)
       config.babel_config_version = 1
     end
 

--- a/test/test_apps/5.0/config/application.rb
+++ b/test/test_apps/5.0/config/application.rb
@@ -19,7 +19,6 @@ module TestApp
     # -- all .rb files in that directory are automatically loaded.
 
     configure_sprockets_bumble_d do |config|
-      config.root_dir = File.expand_path('..', __dir__)
       config.babel_config_version = 1
     end
 

--- a/test/test_apps/5.0_amd/config/application.rb
+++ b/test/test_apps/5.0_amd/config/application.rb
@@ -19,7 +19,6 @@ module TestApp
     # -- all .rb files in that directory are automatically loaded.
 
     configure_sprockets_bumble_d do |config|
-      config.root_dir = File.expand_path('..', __dir__)
       config.babel_config_version = 1
       config.transform_to_umd = false
       config.babel_options = {


### PR DESCRIPTION
While sprockets and sprockets-bumble_d can be used outside of Rails applications, they are most commonly used in Rails apps. In a Rails app, it's likely that `node_modules` will be installed in the rails root, so this default should work out of the box for most people that use this gem with Rails. Thus, they'll have one less setting to configure.